### PR TITLE
Guard for old retroarch

### DIFF
--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -1520,6 +1520,7 @@ void retro_set_environment(retro_environment_t cb)
 
 	struct retro_vfs_interface_info vfs_interface_info;
 	vfs_interface_info.required_interface_version = 3;
+	vfs_interface_info.iface = NULL;
 	if (cb(RETRO_ENVIRONMENT_GET_VFS_INTERFACE, &vfs_interface_info))
 		vfs_interface = vfs_interface_info.iface;
 }


### PR DESCRIPTION
Old retroarch returns true when requested vfs but doesn't touch iface,
set it to NULL for safety