### PR TITLE
Decrease Android SDK requirement to 16

### DIFF
--- a/src/libretro/jni/Application.mk
+++ b/src/libretro/jni/Application.mk
@@ -1,3 +1,3 @@
 APP_ABI := all
 APP_STL := c++_static
-APP_PLATFORM := android-21
+APP_PLATFORM := android-16


### PR DESCRIPTION
We don't need FTS anymore, so 16 is enough