### PR TITLE
Type cleanup for serializarion

### DIFF
--- a/src/actor.cpp
+++ b/src/actor.cpp
@@ -126,7 +126,7 @@ FArchive &operator<< (FArchive &arc, const Frame *&frame)
 	else
 	{
 		const ClassDef *cls;
-		unsigned int frameIndex;
+		DWORD frameIndex;
 
 		arc << cls;
 		if(cls)

--- a/src/actordef.h
+++ b/src/actordef.h
@@ -115,7 +115,7 @@ class Frame
 				bool operator() (AActor *self, AActor *stateOwner, const Frame * const caller, struct ActionResult *result=NULL) const;
 		} action, thinker;
 		const Frame	*next;
-		unsigned int	index;
+		DWORD	index;
 
 		unsigned int	spriteInf;
 

--- a/src/farchive.h
+++ b/src/farchive.h
@@ -216,9 +216,6 @@ virtual void Read (void *mem, unsigned int len);
 inline	FArchive& operator<< (SBYTE &c) { return operator<< ((BYTE &)c); }
 inline	FArchive& operator<< (SWORD &s) { return operator<< ((WORD &)s); }
 inline	FArchive& operator<< (SDWORD &i) { return operator<< ((DWORD &)i); }
-#if defined (__MINGW32__) || defined(_3DS) || defined(VITA)
-inline	FArchive& operator<< (unsigned int &i) { return operator<< ((DWORD &)i); }
-#endif
 inline	FArchive& operator<< (SQWORD &i) { return operator<< ((QWORD &)i); }
 inline	FArchive& operator<< (unsigned char *&str) { return operator<< ((char *&)str); }
 inline	FArchive& operator<< (signed char *&str) { return operator<< ((char *&)str); }

--- a/src/g_blake/blake_sbar.cpp
+++ b/src/g_blake/blake_sbar.cpp
@@ -183,7 +183,7 @@ void BlakeStatusBar::DrawStatusBar()
 
 	// Draw bottom information
 	FString health;
-	health.Format("%3d", players[0].health);
+	health.Format("%3d", (int) players[0].health);
 	DrawString(HealthFont, health, 128, 162, false);
 
 	FString score;

--- a/src/g_wolf/wolf_sbar.cpp
+++ b/src/g_wolf/wolf_sbar.cpp
@@ -297,9 +297,9 @@ void WolfStatusBar::LatchNumber (int x, int y, unsigned width, int32_t number, b
 {
 	FString str;
 	if(zerofill)
-		str.Format("%0*d", width, number);
+		str.Format("%0*d", width, (int) number);
 	else
-		str.Format("%*d", width, number);
+		str.Format("%*d", width, (int) number);
 	if(str.Len() > width && cap)
 	{
 		int maxval = width <= 9 ? ninestbl[width] : INT_MAX;

--- a/src/gamemap.cpp
+++ b/src/gamemap.cpp
@@ -714,7 +714,7 @@ FArchive &operator<< (FArchive &arc, GameMap *&gm)
 	{
 		if(arc.IsStoring())
 		{
-			unsigned int count = gm->elevatorPosition.CountUsed();
+			uint32_t count = gm->elevatorPosition.CountUsed();
 			arc << count;
 
 			TMap<unsigned int, MapSpot>::Iterator iter(gm->elevatorPosition);
@@ -727,7 +727,7 @@ FArchive &operator<< (FArchive &arc, GameMap *&gm)
 		}
 		else
 		{
-			unsigned int count;
+			uint32_t count;
 			arc << count;
 
 			gm->elevatorPosition.Clear();
@@ -751,8 +751,8 @@ FArchive &operator<< (FArchive &arc, MapSpot &spot)
 {
 	if(arc.IsStoring())
 	{
-		unsigned int x = INT_MAX;
-		unsigned int y = INT_MAX;
+		uint32_t x = INT32_MAX;
+		uint32_t y = INT32_MAX;
 		if(spot)
 		{
 			x = spot->GetX();
@@ -763,7 +763,7 @@ FArchive &operator<< (FArchive &arc, MapSpot &spot)
 	}
 	else
 	{
-		unsigned int x, y;
+		uint32_t x, y;
 		arc << x << y;
 
 		if(x == INT_MAX || y == INT_MAX)
@@ -779,12 +779,12 @@ FArchive &operator<< (FArchive &arc, const MapSector *&sector)
 {
 	if(arc.IsStoring())
 	{
-		unsigned int index = map->GetSectorIndex(sector);
+		uint32_t index = map->GetSectorIndex(sector);
 		arc << index;
 	}
 	else
 	{
-		unsigned int index;
+		uint32_t index;
 		arc << index;
 
 		sector = map->GetSector(index);
@@ -796,12 +796,12 @@ FArchive &operator<< (FArchive &arc, const MapTile *&tile)
 {
 	if(arc.IsStoring())
 	{
-		unsigned int index = map->GetTileIndex(tile);
+		uint32_t index = map->GetTileIndex(tile);
 		arc << index;
 	}
 	else
 	{
-		unsigned int index;
+		uint32_t index;
 		arc << index;
 
 		tile = map->GetTile(index);
@@ -813,7 +813,7 @@ FArchive &operator<< (FArchive &arc, const MapZone *&zone)
 {
 	if(arc.IsStoring())
 	{
-		unsigned int index;
+		uint32_t index;
 		if(zone)
 			index = zone->index;
 		else
@@ -823,7 +823,7 @@ FArchive &operator<< (FArchive &arc, const MapZone *&zone)
 	}
 	else
 	{
-		unsigned int index;
+		uint32_t index;
 		arc << index;
 
 		if(index != INT_MAX)

--- a/src/gamemap.h
+++ b/src/gamemap.h
@@ -63,9 +63,9 @@ class GameMap
 		{
 			FString name;
 			FString music;
-			unsigned int width;
-			unsigned int height;
-			unsigned int tileSize;
+			uint32_t width;
+			uint32_t height;
+			uint32_t tileSize;
 		};
 		struct Thing
 		{
@@ -93,13 +93,13 @@ class GameMap
 				arg[0] = arg[1] = arg[2] = arg[3] = arg[4] = 0;
 			}
 
-			unsigned int	x, y, z;
+			uint32_t	x, y, z;
 			// Stores if the trigger hasn't been used yet.
 			// Note that this is set to false on for repeatable actions as well so that secrets are only accounted for once.
 			bool			active;
 
 			enum Side { East, North, West, South };
-			unsigned int	action;
+			uint32_t	action;
 			bool			activate[4];
 			int32_t				arg[5];
 
@@ -142,7 +142,7 @@ class GameMap
 		{
 			const GameMap	*gm;
 
-			unsigned int	depth;
+			uint32_t	depth;
 			struct Map
 			{
 				Map() : tile(NULL), sector(NULL), zone(NULL), visible(false),
@@ -169,14 +169,14 @@ class GameMap
 				FTextureID		texture[4];
 
 				bool			visible;
-				unsigned int	amFlags;
+				uint32_t	amFlags;
 				TObjPtr<Thinker> thinker;
-				unsigned int	slideAmount[4];
-				unsigned int	slideStyle;
+				uint32_t	slideAmount[4];
+				uint32_t	slideStyle;
 				bool			sideSolid[4];
 				TArray<Trigger>	triggers;
 				Tile::Side		pushDirection;
-				unsigned int	pushAmount;
+				uint32_t	pushAmount;
 				Map				*pushReceptor;
 
 				unsigned int	tag;

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -1456,7 +1456,8 @@ void retro_run(void)
 		expectframes = !!TopLoopStep(&g_state, &input);
 		if (expectframes != g_state.frame_counter - oldfc) {
 			fprintf(stderr, "State %d[%d] produces %d frames but reports %d\n", oldstage, oldQuiz,
-				g_state.frame_counter - oldfc, expectframes);
+				(int) g_state.frame_counter - (int) oldfc,
+				expectframes);
 		}
 	}
 	while (expectframes == 0);
@@ -1783,7 +1784,7 @@ void SerializeExtra(FArchive &arc, bool &isGameless, DWORD &version)
 	}
 
 	if (serialize_version >= 11) {
-		arc << automap;
+		arc << (DWORD &) automap;
 		arc << Paused;
 	}
 	arc << (DWORD &) playstate;

--- a/src/libretro/state_machine.h
+++ b/src/libretro/state_machine.h
@@ -293,7 +293,7 @@ typedef struct wl_state_s {
 	SDWORD textposition;
 	SDWORD pagenum;
 	SDWORD numpages;
-	unsigned rowon;
+	uint32_t rowon;
 	byte    fontcolor;
 	int32_t     picx;
 	int32_t     picy;

--- a/src/libretro/wl_inter.cpp
+++ b/src/libretro/wl_inter.cpp
@@ -189,7 +189,7 @@ static void ContinueCounting(wl_state_t *state)
 	}
 
 	if(state->countCurrent) Erase (tx, ty, tempstr, true);
-	tempstr.Format("%d", state->countCurrent);
+	tempstr.Format("%d", (int) state->countCurrent);
 	Write (tx, ty, tempstr, true, state->bonusFont);
 	state->prevCount = tempstr;
 	if (state->intermissionSndFreq == 0)
@@ -250,10 +250,10 @@ static void InterAddBonus(wl_state_t *state, unsigned int bonus, bool count=fals
 	}
 
 	FString bonusstr;
-	bonusstr.Format("%u", InterState.bonus);
+	bonusstr.Format("%u", (unsigned) InterState.bonus);
 	Erase (36, y>>3, bonusstr, true);
 	InterState.bonus += bonus;
-	bonusstr.Format("%u", InterState.bonus);
+	bonusstr.Format("%u", (unsigned) InterState.bonus);
 	Write (36, y>>3, bonusstr, true, InterState.graphical);
 	VW_UpdateScreen ();
 }
@@ -347,7 +347,7 @@ static void InterStartNormal()
 
 	// Write the starting value based on InterState.bonus in case ForceTally is on
 	FString bonusstr;
-	bonusstr.Format("%u", InterState.bonus);
+	bonusstr.Format("%u", (unsigned) InterState.bonus);
 	Write (36, 7, bonusstr, true);
 
 	Write (37, 14, "%");
@@ -370,7 +370,7 @@ static void InterStartGraphical(wl_state_t *state)
 	VWB_DrawGraphic(TexMan(GraphicalTexID[WI_BONUS]), 104, 72);
 	// Write the starting value based on InterState.bonus in case ForceTally is on
 	FString bonusstr;
-	bonusstr.Format("%u", InterState.bonus);
+	bonusstr.Format("%u", (unsigned) InterState.bonus);
 	Write (36, 9, bonusstr, true, true);
 #ifdef TODO
 	VW_UpdateScreen ();
@@ -779,7 +779,7 @@ void DrawHighScores (void)
 		//
 		// score
 		//
-		buffer.Format("%d", s->score);
+		buffer.Format("%d", (int) s->score);
 		VW_MeasurePropString (font, buffer, w, h);
 		PrintX = 292 - w;
 		US_Print (font, buffer, gameinfo.FontColors[GameInfo::HIGHSCORES]);

--- a/src/libretro/wl_text.cpp
+++ b/src/libretro/wl_text.cpp
@@ -563,7 +563,8 @@ static void PageLayout (wl_state_t *state, bool shownumber, bool helphack)
 	if (shownumber)
 	{
 		FString str;
-		str.Format("pg %d of %d", state->pagenum, state->numpages);
+		str.Format("pg %d of %d", (int) state->pagenum,
+			   (int) state->numpages);
 		px = 213;
 		py = 183;
 

--- a/src/lnspec.cpp
+++ b/src/lnspec.cpp
@@ -55,9 +55,9 @@ using namespace Specials;
 static FRandom pr_teleport("Teleport");
 
 #define DEFINE_SPECIAL(name,num,argc) \
-	static int LN_##name(MapSpot spot, const int args[], MapTrigger::Side direction, AActor *activator);
+	static int LN_##name(MapSpot spot, const int32_t args[], MapTrigger::Side direction, AActor *activator);
 #define FUNC(name) \
-	static int LN_##name(MapSpot spot, const int args[], MapTrigger::Side direction, AActor *activator)
+	static int LN_##name(MapSpot spot, const int32_t args[], MapTrigger::Side direction, AActor *activator)
 
 DEFINE_SPECIAL(NOP, 0, 0)
 #include "lnspecials.h"
@@ -326,10 +326,10 @@ class EVDoor : public Thinker
 		SndSeqPlayer *sndseq;
 		FName seqname;
 
-		unsigned int speed;
+		uint32_t speed;
 		int32_t amount;
 		int32_t opentics;
-		unsigned int wait;
+		uint32_t wait;
 		bool direction;
 };
 IMPLEMENT_INTERNAL_CLASS(EVDoor)
@@ -627,8 +627,8 @@ private:
 	MapSpot door;
 	MapSpot next;
 	MapSpot nextDoor;
-	unsigned int elevTag;
-	unsigned int callSpeed;
+	uint32_t elevTag;
+	uint32_t callSpeed;
 	State state;
 };
 IMPLEMENT_INTERNAL_POINTY_CLASS(EVElevator)
@@ -871,9 +871,9 @@ class EVPushwall : public Thinker
 		FName seqname;
 
 		unsigned short	direction;
-		unsigned int	position;
-		unsigned int	speed;
-		unsigned int	distance;
+		uint32_t	position;
+		uint32_t	speed;
+		uint32_t	distance;
 		bool nostop;
 };
 IMPLEMENT_INTERNAL_CLASS(EVPushwall)
@@ -1081,7 +1081,7 @@ class EVVictorySpin : public Thinker
 		}
 
 		bool			doturn;
-		unsigned int	dist;
+		uint32_t	dist;
 		TObjPtr<AActor>	activator;
 		TObjPtr<AActor>	runner;
 };

--- a/src/lnspec.h
+++ b/src/lnspec.h
@@ -44,7 +44,7 @@ bool P_ChangeSwitchTexture (MapSpot spot, MapTile::Side side, int useAgain, BYTE
 
 namespace Specials
 {
-	typedef int (*LineSpecialFunction)(MapSpot spot, const int args[], MapTrigger::Side direction, AActor *activator);
+	typedef int (*LineSpecialFunction)(MapSpot spot, const int32_t args[], MapTrigger::Side direction, AActor *activator);
 
 	#define DEFINE_SPECIAL(name,num,args) name = num,
 	enum LineSpecials

--- a/src/m_random.h
+++ b/src/m_random.h
@@ -209,7 +209,7 @@ private:
 	union
 	{
 		w128_t w128[SFMT::N];
-		unsigned int u[SFMT::N32];
+		uint32_t u[SFMT::N32];
 		QWORD u64[SFMT::N64];
 	} sfmt;
 	/** index counter to the 32-bit internal state array */

--- a/src/sndseq.cpp
+++ b/src/sndseq.cpp
@@ -310,7 +310,7 @@ FArchive &operator<< (FArchive &arc, SndSeqPlayer *&seqplayer)
 {
 	FName seqname;
 	MapSpot source;
-	unsigned int offs;
+	uint32_t offs;
 
 	if(arc.IsStoring())
 	{

--- a/src/sndseq.h
+++ b/src/sndseq.h
@@ -126,7 +126,7 @@ private:
 	const SndSeqInstruction *Current;
 	MapSpot Source;
 
-	unsigned int Delay;
+	uint32_t Delay;
 	bool Playing;
 	bool WaitForDone;
 };

--- a/src/wl_inter.h
+++ b/src/wl_inter.h
@@ -11,12 +11,12 @@
 
 extern struct LRstruct
 {
-	unsigned int killratio;
-	unsigned int secretsratio;
-	unsigned int treasureratio;
-	unsigned int numLevels;
-	unsigned int time;
-	unsigned int par;
+	uint32_t killratio;
+	uint32_t secretsratio;
+	uint32_t treasureratio;
+	uint32_t numLevels;
+	uint32_t time;
+	uint32_t par;
 } LevelRatios;
 
 void DrawHighScores(void);


### PR DESCRIPTION
Whether DWORD is int or long int for 32-bit platforms depends on compiler
version. Since on some platforms like consoles real configure tests can
be cumbersome, let's just use DWORD/uint32_t instead of unsigned int