### PR TITLE
Fix the use of OWN_ADDED_SIZE with respect to alignment

### DIFF
--- a/src/m_alloc.cpp
+++ b/src/m_alloc.cpp
@@ -52,10 +52,24 @@
 #if defined(__APPLE__)
 #define _msize(p)				malloc_size(p)
 #elif defined(__sun) || defined(__ANDROID__) || defined(__QNX__) || defined(USE_OWN_ADDED_SIZE) || defined(__DJGPP__) || defined(__UCLIBC__) && !defined(HAS_MALLOC_USABLE_SIZE)
-#define _msize(p)				(*((size_t*)(p)-1))
+#define _msize(p)				(((alloc_header*)(p)-1)->alloc_size)
 #define OWN_ADDED_SIZE 1
 #elif !defined(_WIN32)
 #define _msize(p)				malloc_usable_size(p)	// from glibc/FreeBSD
+#endif
+
+#if defined(OWN_ADDED_SIZE)
+union alloc_header {
+	// The only part really used
+	size_t alloc_size;
+	// Rest is to ensure proper alignment
+	void *ptr;
+	double d;
+	float f;
+	int i;
+	long l;
+	long long ll;
+};
 #endif
 
 #ifndef _DEBUG
@@ -88,13 +102,13 @@ void *M_Realloc(void *memblock, size_t size)
 #else
 void *M_Malloc(size_t size)
 {
-	void *block = malloc(size+sizeof(size_t));
+	void *block = malloc(size+sizeof(alloc_header));
 
 	if (block == NULL)
 		I_FatalError("Could not malloc %zu bytes", size);
 
-	size_t *sizeStore = (size_t *) block;
-	*sizeStore = size;
+	alloc_header *sizeStore = (alloc_header *) block;
+	sizeStore->alloc_size = size;
 	block = sizeStore+1;
 
 	GC::AllocBytes += _msize(block);
@@ -110,14 +124,14 @@ void *M_Realloc(void *memblock, size_t size)
 	{
 		GC::AllocBytes -= _msize(memblock);
 	}
-	void *block = realloc(((size_t*) memblock)-1, size+sizeof(size_t));
+	void *block = realloc(((alloc_header*) memblock)-1, size+sizeof(alloc_header));
 	if (block == NULL)
 	{
 		I_FatalError("Could not realloc %zu bytes", size);
 	}
 
-	size_t *sizeStore = (size_t *) block;
-	*sizeStore = size;
+	alloc_header *sizeStore = (alloc_header *) block;
+	sizeStore->alloc_size = size;
 	block = sizeStore+1;
 
 	GC::AllocBytes += _msize(block);
@@ -163,8 +177,8 @@ void *M_Malloc_Dbg(size_t size, const char *file, int lineno)
 	if (block == NULL)
 		I_FatalError("Could not malloc %zu bytes", size);
 
-	size_t *sizeStore = (size_t *) block;
-	*sizeStore = size;
+	alloc_header *sizeStore = (alloc_header *) block;
+	sizeStore->alloc_size = size;
 	block = sizeStore+1;
 
 	GC::AllocBytes += _msize(block);
@@ -180,15 +194,15 @@ void *M_Realloc_Dbg(void *memblock, size_t size, const char *file, int lineno)
 	{
 		GC::AllocBytes -= _msize(memblock);
 	}
-	void *block = _realloc_dbg(((size_t*) memblock)-1, size+sizeof(size_t), _NORMAL_BLOCK, file, lineno);
+	alloc_header *block = _realloc_dbg(((alloc_header*) memblock)-1, size+sizeof(alloc_header), _NORMAL_BLOCK, file, lineno);
 
 	if (block == NULL)
 	{
 		I_FatalError("Could not realloc %zu bytes", size);
 	}
 
-	size_t *sizeStore = (size_t *) block;
-	*sizeStore = size;
+	alloc_header *sizeStore = (alloc_header *) block;
+	sizeStore->alloc_size = size;
 	block = sizeStore+1;
 
 	GC::AllocBytes += _msize(block);
@@ -212,7 +226,7 @@ void M_Free (void *block)
 	if(block != NULL)
 	{
 		GC::AllocBytes -= _msize(block);
-		free(((size_t*) block)-1);
+		free(((alloc_header *) block)-1);
 	}
 }
 #endif


### PR DESCRIPTION
size_t is 32-bit on some mips but double is 64-bit aligned. So M_Malloc returns
a pointer that is unsuitable for an array of doubles. Fix it by using union of
different possible types instead in order to enforce alignment.