### PR TITLE
miyoo: Use low memory configuration

### DIFF
--- a/src/libretro/Makefile
+++ b/src/libretro/Makefile
@@ -366,10 +366,9 @@ else ifeq ($(platform), miyoo)
 	CC = /opt/miyoo/usr/bin/arm-linux-gcc
 	CXX = /opt/miyoo/usr/bin/arm-linux-g++
 	AR = /opt/miyoo/usr/bin/arm-linux-ar
-	COMMON_CFLAGS += -D_GNU_SOURCE -DUSE_OWN_ADDED_SIZE
+	COMMON_CFLAGS += -DUSE_OWN_ADDED_SIZE
 	COMMON_CFLAGS += -fomit-frame-pointer -ffast-math -march=armv5te -mtune=arm926ej-s
-	COMMON_CFLAGS += -fno-common -ftree-vectorize -funswitch-loops
-   COMMON_CFLAGS += -Dstricmp=strcasecmp -Dstrnicmp=strncasecmp
+	COMMON_CFLAGS += -Dstricmp=strcasecmp -Dstrnicmp=strncasecmp -DMIYOO
 else
    CC ?= gcc
    TARGET := $(TARGET_NAME)_libretro.dll

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -596,7 +596,7 @@ static void am_multiple_choice (const char *name, unsigned &var, bool &is_update
 
 static void update_variables(bool startup)
 {
-#if defined(RS90)
+#if defined(RS90) || defined(MIYOO)
 	store_files_in_memory = false;
 #elif defined(_3DS) || defined(GEKKO)
 	store_files_in_memory = true;
@@ -1116,7 +1116,7 @@ static void mixChannel(long long tic, SoundChannelState *channel)
 #define MB(x) ((x) << 20)
 
 size_t limit_sound_cache_size =
-#ifdef RS90
+#if defined(RS90) || defined(MIYOO)
 	MB(5)
 #else
 	MB(15)
@@ -1137,7 +1137,7 @@ void generate_audio(long long tic)
 		// We don't want to keep dropping and reloading the same files every frame
 		if (limit_sound_cache_size <= (touched_sound_size * 3) / 2) {
 			limit_sound_cache_size = (touched_sound_size * 3) / 2;
-#ifdef RS90
+#if defined(RS90) || defined(MIYOO)
 			if (limit_sound_cache_size >= MB(7))
 				limit_sound_cache_size = MB(7);
 #endif		

--- a/src/libretro/libretro_core_options.h
+++ b/src/libretro/libretro_core_options.h
@@ -372,7 +372,7 @@ struct retro_core_option_definition option_defs_us[] = {
 		BOOL_OPTIONS,
 		"disabled"
 	},
-#if !defined(_3DS) && !defined(GEKKO) && !defined(RS90)
+#if !defined(_3DS) && !defined(GEKKO) && !defined(RS90) && !defined(MIYOO)
 	{
 		"ecwolf-memstore",
 		"Store files in memory",
@@ -381,6 +381,7 @@ struct retro_core_option_definition option_defs_us[] = {
 		"disabled"
 	},
 #endif
+#if !defined(RS90)
 	{
 		"ecwolf-preload-digisounds",
 		"Preload digitized sounds",
@@ -388,6 +389,7 @@ struct retro_core_option_definition option_defs_us[] = {
 		BOOL_OPTIONS,
 		"enabled"
 	},
+#endif
 	{
 		"ecwolf-panx-adjustment",
 		"Horizontal panning speed in automap",


### PR DESCRIPTION
Use the same not storing files in memory, no preload digital sounds and
small cache configuration as the RS-90 as it also only has 32MB RAM.
Also remove irrelevant build flags.

@phcoder I removed the `ecwolf-preload-digisound` config option from RS-90 as well since it's hard-coded as disabled.