### PR TITLE
Fix name of vertical panning option

### DIFF
--- a/src/libretro/libretro_core_options.h
+++ b/src/libretro/libretro_core_options.h
@@ -397,8 +397,8 @@ struct retro_core_option_definition option_defs_us[] = {
 	},
 	{
 		"ecwolf-pany-adjustment",
-		"Horizontal panning speed in automap",
-		"Multiplier for horizontal panning from 0 to 20",
+		"Vertical panning speed in automap",
+		"Multiplier for vertical panning from 0 to 20",
 		SLIDER_OPTIONS,
 		"5"
 	},


### PR DESCRIPTION
## Description

This PR fixes an error which looks like it was introduced in https://github.com/libretro/ecwolf/pull/44. The setting `Horizontal panning speed in automap` appears twice for both X and Y panning. I assume the second instance should be vertical panning.

