### PR TITLE
Fix segfault on close content on Windows

### DIFF
--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -316,6 +316,7 @@ bool IVideo::SetResolution (int width, int height, int bits)
 	}
 
 	if (screen) {
+		screen->ObjectFlags |= OF_YesReallyDelete;
 		delete screen;
 	}
 
@@ -339,6 +340,11 @@ void I_InitGraphics () {
 }
 
 void I_ShutdownGraphics () {
+	if (screen) {
+		screen->ObjectFlags |= OF_YesReallyDelete;
+		delete screen;
+		screen = NULL;
+	}
 }
 
 static struct retro_frame_time_callback frame_cb;   
@@ -418,10 +424,6 @@ void retro_unload_game()
 {
 	SoundInfo.Clear();
 	CallTerminateFunctions();
-	if (screen) {
-		delete screen;
-		screen = NULL;
-	}
 }
 
 static char g_wad_dir[1024];

--- a/src/libretro/libretro_core_options.h
+++ b/src/libretro/libretro_core_options.h
@@ -53,9 +53,6 @@ extern "C" {
 #define SLIDER_OPTIONS		 \
 	{			 \
 		{ "Off", NULL }, \
-		{ "1", NULL },	 \
-		{ "2", NULL },	 \
-		{ "3", NULL },   \
 		{ "1", NULL },   \
 		{ "2", NULL },   \
 		{ "3", NULL },   \


### PR DESCRIPTION
`I_ShutdownGraphics()` is called during `CallTerminateFunctions()` so delete "screen" here, this prevents a crash on close content on Windows (and I double checked on my Linux VM, it doesn't break anything and it still closes fine there).

Also removed the "'xxx' is freed outside the GC process." warnings.

**edit:** Unrelated but force pushed some removals for repeated values in the "SLIDER_OPTIONS" macro that I just spotted.

Closes #91